### PR TITLE
The mail compiler is less opinionated.

### DIFF
--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -28,7 +28,9 @@ Setup with Rails could not be easier.
 gem 'bootstrap-email'
 ```
 
-2: Create a new file `/app/views/layouts/bootstrap-mailer.html.erb` and paste this HTML into it. (It is very similar to the default one.)
+2: Create a new file `/app/views/layouts/example_mailer.html.erb` and paste this HTML into it. (It is very similar to the default one).
+
+The name of this file follows the rules of ActionMailer, that loads a layout deriving the name from the mailer class name.
 
 ```erb
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
@@ -55,14 +57,20 @@ gem 'bootstrap-email'
 Rails.application.config.assets.precompile += %w( application-mailer.scss )
 ```
 
+5: Create the view file `/app/views/example_mailer/greet.html.erb`.
+
+You can also create the view `/app/views/example_mailer/greet.text.erb`. In this case don't forget to create also the textual layout `/app/views/layouts/example_mailer.text.erb`.
+
+If you do  not create a textual view file, a text part is automatically added by the `premailer-rails` gem.
+
 ### Usage
-Thats it! Now all you need to do to use it instead of using the `mail()` method, you use the `bootstrap_mail()` method to kick off Bootstrap Email compilation!
+Thats it! Now all you need to do to use it instead of using the `mail()` method, you use the `make_bootstrap_mail()` method to kick off Bootstrap Email compilation!
 
 ```ruby
 class ExampleMailer < ApplicationMailer
 
-  def show
-    bootstrap_mail(
+  def greet
+    make_bootstrap_mail(
       to: 'to@example.com',
       from: 'from@example.com',
       subject: 'Hi From Bootstrap Email',
@@ -70,3 +78,23 @@ class ExampleMailer < ApplicationMailer
   end
 end
 ```
+
+You can also use the `format` in the usual way.
+```ruby
+class ExampleMailer < ApplicationMailer
+
+  def greet
+    make_bootstrap_mail(
+      to: 'to@example.com',
+      from: 'from@example.com',
+      subject: 'Hi From Bootstrap Email',
+      ) do |format|
+        format.html { layout 'custom_bootstrap_layout' }
+        format.text # here example_mailer.text.erb is used
+      end
+  end
+end
+```
+
+### Compatibility note
+The old method `bootstrap_mail` is still available for compatibility.

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -31,6 +31,7 @@ gem 'bootstrap-email'
 2: Create a new file `/app/views/layouts/example_mailer.html.erb` and paste this HTML into it. (It is very similar to the default one).
 
 The name of this file follows the rules of ActionMailer, that loads a layout deriving the name from the mailer class name.
+If you want a different behaviour, such as using the same template for all the mailers, or specifying a template for a single method, refer to the [official ActionMailer documentation](http://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-layouts).
 
 ```erb
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">

--- a/lib/bootstrap-email.rb
+++ b/lib/bootstrap-email.rb
@@ -11,7 +11,8 @@ module BootstrapEmail
 
     def initialize mail
       @mail = mail
-      self.update_doc(@mail.body.raw_source)
+      @source = mail.html_part || mail
+      self.update_doc(@source.body.raw_source)
     end
 
     def update_doc source
@@ -42,7 +43,7 @@ module BootstrapEmail
     end
 
     def inline_css!
-      @mail.body = @doc.to_html
+      @source.body = @doc.to_html
       @mail = Premailer::Rails::Hook.perform(@mail)
       @mail.header[:skip_premailer] = true
       self.update_doc(@mail.html_part.body.raw_source)

--- a/lib/bootstrap-email/action_mailer.rb
+++ b/lib/bootstrap-email/action_mailer.rb
@@ -5,4 +5,9 @@ class ActionMailer::Base
     bootstrap = BootstrapEmail::Compiler.new(mail(*args) { |format| format.html { render layout: 'layouts/bootstrap-mailer.html.erb' } } )
     bootstrap.perform_full_compile
   end
+
+  def make_bootstrap_mail *args, &block
+    bootstrap = BootstrapEmail::Compiler.new(mail(*args, &block))
+    bootstrap.perform_full_compile
+  end
 end


### PR DESCRIPTION
A new method `make_bootstrap_mail` is introduced aimed to replace the
method `bootstrap_mail` that has been kept for compatibility.

The new method does not impose the layout name, furthermore it allows the
developer to write a textual version of the mail without beign compelled
to use the auto generated one make by the `premailer-rails` gem.