### PR TITLE
Set the font-size with default to 16px, so that the font size can be set outside.

### DIFF
--- a/core/sass/_variables.scss
+++ b/core/sass/_variables.scss
@@ -1,4 +1,4 @@
-$font-size-base: 16px;
+$font-size-base: 16px !default; 
 $line-height-base: 1.5;
 $headings-line-height: 1.2;
 $headings-ratios: (1: 2.25, 2: 2, 3: 1.75, 4: 1.5, 5: 1.25, 6: 1);


### PR DESCRIPTION
So when importing the css in mailer.scss, we can do something like this

```scss
   $font-size-base: 12px; 
   @import 'bootstrap-email';
```