### PR TITLE
Make more styles configurable w/ variables

### DIFF
--- a/core/bootstrap-email.scss
+++ b/core/bootstrap-email.scss
@@ -16,3 +16,4 @@
 @import 'sass/color';
 @import 'sass/preview';
 @import 'sass/spacing';
+@import 'sass/border';

--- a/core/sass/_border.scss
+++ b/core/sass/_border.scss
@@ -1,0 +1,73 @@
+//
+// Border
+//
+
+.border         { border: $border-width solid $border-color !important; }
+.border-top     { border-top: $border-width solid $border-color !important; }
+.border-right   { border-right: $border-width solid $border-color !important; }
+.border-bottom  { border-bottom: $border-width solid $border-color !important; }
+.border-left    { border-left: $border-width solid $border-color !important; }
+
+.border-0        { border: 0 !important; }
+.border-top-0    { border-top: 0 !important; }
+.border-right-0  { border-right: 0 !important; }
+.border-bottom-0 { border-bottom: 0 !important; }
+.border-left-0   { border-left: 0 !important; }
+
+@each $color, $value in $theme-colors {
+  .border-#{$color} {
+    border-color: $value !important;
+  }
+}
+
+.border-white {
+  border-color: $white !important;
+}
+
+//
+// Border-radius
+//
+
+.rounded-sm {
+  border-radius: $border-radius-sm !important;
+}
+
+.rounded {
+  border-radius: $border-radius !important;
+}
+
+.rounded-top {
+  border-top-left-radius: $border-radius !important;
+  border-top-right-radius: $border-radius !important;
+}
+
+.rounded-right {
+  border-top-right-radius: $border-radius !important;
+  border-bottom-right-radius: $border-radius !important;
+}
+
+.rounded-bottom {
+  border-bottom-right-radius: $border-radius !important;
+  border-bottom-left-radius: $border-radius !important;
+}
+
+.rounded-left {
+  border-top-left-radius: $border-radius !important;
+  border-bottom-left-radius: $border-radius !important;
+}
+
+.rounded-lg {
+  border-radius: $border-radius-lg !important;
+}
+
+.rounded-circle {
+  border-radius: 50% !important;
+}
+
+.rounded-pill {
+  border-radius: $rounded-pill !important;
+}
+
+.rounded-0 {
+  border-radius: 0 !important;
+}

--- a/core/sass/_button.scss
+++ b/core/sass/_button.scss
@@ -1,23 +1,23 @@
 .btn {
-  border-radius: 4px;
+  border-radius: $btn-border-radius;
   border-collapse: separate !important;
 }
 
 .btn td {
-  border-radius: 4px;
+  border-radius: $btn-border-radius;
   text-align: center;
 }
 
 .btn td a {
-  font-size: 16px;
-  font-family: Helvetica, Arial, sans-serif;
+  font-size: $btn-font-size;
+  font-family: $btn-font-family;
   text-decoration: none;
-  border-radius: 4px;
-  padding: 8px 12px;
-  line-height: 1.25 * $font-size-base;
-  border: 1px solid #e9703e;
+  border-radius: $btn-border-radius;
+  padding: $btn-padding-y $btn-padding-x;
+  line-height: $btn-line-height;
+  border: $btn-border-width solid transparent;
   display: inline-block;
-  font-weight: normal;
+  font-weight: $btn-font-weight;
   white-space: nowrap;
 }
 
@@ -45,15 +45,15 @@
 }
 
 .btn-sm td a {
-  font-size: .875 * $font-size-base;
-  padding: .25 * $font-size-base .5 * $font-size-base;
-  line-height: 1.5 * .875 * $font-size-base;
-  border-radius: .2 * $font-size-base;
+  font-size: $btn-font-size-sm;
+  padding: $btn-padding-y-sm $btn-padding-x-sm;
+  line-height: $btn-line-height-sm;
+  border-radius: $btn-border-radius-sm;
 }
 
 .btn-lg td a {
-  font-size: 1.25 * $font-size-base;
-  padding: .5 * $font-size-base 1 * $font-size-base;
-  line-height: 1.5 * 1.25 * $font-size-base;
-  border-radius: .3 * $font-size-base;
+  font-size: $btn-font-size-lg;
+  padding: $btn-padding-y-lg $btn-padding-x-lg;
+  line-height: $btn-line-height-lg;
+  border-radius: $btn-border-radius-lg;
 }

--- a/core/sass/_color.scss
+++ b/core/sass/_color.scss
@@ -5,6 +5,16 @@
   }
 }
 
+.bg-white,
+.bg-white > tbody > tr > td {
+  background-color: $white !important;
+}
+
+.bg-transparent,
+.bg-transparent > tbody > tr > td {
+  background-color: transparent !important;
+}
+
 @each $color, $value in $theme-colors {
   .text-#{$color},
   .text-#{$color} > tbody > tr > td {

--- a/core/sass/_reboot_email.scss
+++ b/core/sass/_reboot_email.scss
@@ -10,7 +10,7 @@ body, .body {
   height: 100%;
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
-  font-family: $font-family-sans-serif;
+  font-family: $font-family-base;
   line-height: $line-height-base * $font-size-base;
   font-weight: normal;
   font-size: $font-size-base;
@@ -33,7 +33,7 @@ a img {
 
 // don't apply to spacers
 table:not([class^=s-]) {
-  font-family: $font-family-sans-serif;
+  font-family: $font-family-base;
   mso-table-lspace: 0pt;
   mso-table-rspace: 0pt;
 }
@@ -60,4 +60,3 @@ p {
   font-size: $font-size-base;
   margin: 0;
 }
-

--- a/core/sass/_reboot_email.scss
+++ b/core/sass/_reboot_email.scss
@@ -1,7 +1,6 @@
 /* Based on https://templates.mailchimp.com/development/css/reset-styles/ by Mailchimp */
 body, .body {
   margin: 0;
-  Margin: 0;
   padding: 0;
   border: 0;
   outline: 0;
@@ -12,11 +11,13 @@ body, .body {
   -ms-text-size-adjust: 100%;
   font-family: $font-family-base;
   line-height: $line-height-base * $font-size-base;
-  font-weight: normal;
+  font-weight: $font-weight-base;
   font-size: $font-size-base;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
+  background-color: $body-bg;
+  color: $body-color;
 }
 
 img {

--- a/core/sass/_reboot_email.scss
+++ b/core/sass/_reboot_email.scss
@@ -1,6 +1,7 @@
 /* Based on https://templates.mailchimp.com/development/css/reset-styles/ by Mailchimp */
 body, .body {
   margin: 0;
+  Margin: 0; // For compatibility with Outlook https://www.emailonacid.com/blog/article/email-development/outlook-com-does-support-margins/
   padding: 0;
   border: 0;
   outline: 0;

--- a/core/sass/_table.scss
+++ b/core/sass/_table.scss
@@ -5,8 +5,7 @@
 .table {
   width: 100%;
   max-width: 100%;
-  // margin-bottom: $spacer;
-  background-color: $white; // Reset for nesting within parents with `background-color`.
+  background-color: $table-background-color; // Reset for nesting within parents with `background-color`.
 
   & > thead > tr > th {
     text-align: left;
@@ -25,7 +24,7 @@
   }
 }
 
-.table-unstyled{
+.table-unstyled {
   width: 100%;
   max-width: 100%;
   background-color: transparent;
@@ -76,7 +75,7 @@
 
 .table-striped {
   & > tbody > tr:nth-of-type(odd) {
-    background-color: #f2f2f2;
+    background-color: $table-accent-bg;
   }
 }
 

--- a/core/sass/_table.scss
+++ b/core/sass/_table.scss
@@ -98,11 +98,11 @@
 
 
 
-// Inverse styles
+// Dark styles
 //
 // Same table markup, but inverted color scheme: dark background and light text.
 
-.thead-inverse {
+.thead-dark {
   & > thead > tr > th {
     color: $white;
     background-color: $gray-900;
@@ -116,7 +116,7 @@
   }
 }
 
-.table-inverse {
+.table-dark {
   color: $white;
   background-color: $gray-900;
 

--- a/core/sass/_table.scss
+++ b/core/sass/_table.scss
@@ -102,14 +102,14 @@
 // Same table markup, but inverted color scheme: dark background and light text.
 
 .thead-dark {
-  & > thead > tr > th {
+  th {
     color: $white;
     background-color: $gray-900;
   }
 }
 
 .thead-default {
-  & > thead > tr > th {
+  th {
     color: $gray-700;
     background-color: $gray-200;
   }

--- a/core/sass/_table.scss
+++ b/core/sass/_table.scss
@@ -9,6 +9,8 @@
 
   & > thead > tr > th {
     text-align: left;
+    vertical-align: bottom;
+    border-bottom: (2 * $table-border-width) solid $table-border-color;
   }
 
   & > thead > tr > th,
@@ -16,11 +18,6 @@
     padding: 0.75 * $font-size-base;
     vertical-align: top;
     border-top: $table-border-width solid $table-border-color;
-  }
-
-  & > thead > th {
-    vertical-align: bottom;
-    border-bottom: (2 * $table-border-width) solid $table-border-color;
   }
 }
 

--- a/core/sass/_table.scss
+++ b/core/sass/_table.scss
@@ -14,7 +14,8 @@
   }
 
   & > thead > tr > th,
-  & > tbody > tr > td {
+  & > tbody > tr > td,
+  & > tfoot > tr > td {
     padding: 0.75 * $font-size-base;
     vertical-align: top;
     border-top: $table-border-width solid $table-border-color;
@@ -39,7 +40,8 @@
 
 .table-sm {
   & > thead > tr > th,
-  & > tbody > tr > td {
+  & > tbody > tr > td,
+  & > tfoot > tr > td {
     padding: 0.3 * $font-size-base;;
   }
 }
@@ -53,7 +55,8 @@
   border: $table-border-width solid $table-border-color;
 
   & > thead > tr > th,
-  & > tbody > tr > td {
+  & > tbody > tr > td,
+  & > tfoot > tr > td {
     border: $table-border-width solid $table-border-color;
   }
 
@@ -117,7 +120,8 @@
   background-color: $gray-900;
 
   & > thead > tr > th,
-  & > tbody > tr > td {
+  & > tbody > tr > td,
+  & > tfoot > tr > td {
     border-color: #32383e;
   }
 

--- a/core/sass/_table.scss
+++ b/core/sass/_table.scss
@@ -108,7 +108,7 @@
   }
 }
 
-.thead-default {
+.thead-light {
   th {
     color: $gray-700;
     background-color: $gray-200;

--- a/core/sass/_typography.scss
+++ b/core/sass/_typography.scss
@@ -28,7 +28,8 @@ h1, h2, h3, h4, h5, h6,
   text-align: center !important;
 }
 
-.p {
+p {
+  margin-bottom: $paragraph-margin-bottom;
   width: 100%;
   & > tbody > tr > td {
     margin: 0;

--- a/core/sass/_typography.scss
+++ b/core/sass/_typography.scss
@@ -1,10 +1,10 @@
 h1, h2, h3, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
-  margin-top: 0;
-  margin-bottom: 0;
-  // margin-bottom: $font-size-base / 2;
-  font-weight: 500;
-  color: inherit;
+  margin-top: $headings-margin-top;
+  margin-bottom: $headings-margin-bottom;
+  font-family: $headings-font-family;
+  font-weight: $headings-font-weight;
+  color: $headings-color;
   text-align: left;
   vertical-align: baseline;
 }

--- a/core/sass/_typography.scss
+++ b/core/sass/_typography.scss
@@ -16,6 +16,14 @@ h1, h2, h3, h4, h5, h6,
   }
 }
 
+.font-weight-bold {
+  font-weight: bold !important;
+}
+
+.font-weight-normal {
+  font-weight: normal !important;
+}
+
 .text-left {
   text-align: left !important;
 }

--- a/core/sass/_variables.scss
+++ b/core/sass/_variables.scss
@@ -89,6 +89,7 @@ $spacers: (
 ) !default;
 
 $font-family-sans-serif: Helvetica, Arial, sans-serif !default;
+$font-family-base: $font-family-sans-serif !default;
 
 $widths: (
   25: 25%,
@@ -104,4 +105,3 @@ $table-border-width: 1px !default;
 // Utility functions
 @function heading-size($n) { @return map-get($headings-ratios, $n) * $font-size-base; }
 @function heading-line-height($n) { @return heading-size($n) * $headings-line-height; }
-

--- a/core/sass/_variables.scss
+++ b/core/sass/_variables.scss
@@ -1,5 +1,7 @@
 $font-size-base: 16px !default;
 $font-weight-base: normal !default;
+$font-family-sans-serif: Helvetica, Arial, sans-serif !default;
+$font-family-base: $font-family-sans-serif !default;
 $border-radius: $font-size-base * 0.25 !default;
 $border-radius-lg: $font-size-base * 0.3 !default;
 $border-radius-sm: $font-size-base * 0.2 !default;
@@ -96,9 +98,6 @@ $spacers: (
   4: ($spacer * 1.5),
   5: ($spacer * 3)
 ) !default;
-
-$font-family-sans-serif: Helvetica, Arial, sans-serif !default;
-$font-family-base: $font-family-sans-serif !default;
 
 $widths: (
   25: 25%,

--- a/core/sass/_variables.scss
+++ b/core/sass/_variables.scss
@@ -1,7 +1,7 @@
-$font-size-base: 16px !default; 
-$line-height-base: 1.5;
-$headings-line-height: 1.2;
-$headings-ratios: (1: 2.25, 2: 2, 3: 1.75, 4: 1.5, 5: 1.25, 6: 1);
+$font-size-base: 16px !default;
+$line-height-base: 1.5 !default;
+$headings-line-height: 1.2 !default;
+$headings-ratios: (1: 2.25, 2: 2, 3: 1.75, 4: 1.5, 5: 1.25, 6: 1) !default;
 
 //
 // Color system
@@ -98,8 +98,8 @@ $widths: (
   auto: auto
 ) !default;
 
-$table-border-color: $gray-200;
-$table-border-width: 1px;
+$table-border-color: $gray-200 !default;
+$table-border-width: 1px !default;
 
 // Utility functions
 @function heading-size($n) { @return map-get($headings-ratios, $n) * $font-size-base; }

--- a/core/sass/_variables.scss
+++ b/core/sass/_variables.scss
@@ -5,6 +5,11 @@ $border-radius-sm: $font-size-base * 0.2 !default;
 $line-height-base: 1.5 !default;
 $headings-line-height: 1.2 !default;
 $headings-ratios: (1: 2.25, 2: 2, 3: 1.75, 4: 1.5, 5: 1.25, 6: 1) !default;
+$headings-margin-top:         0 !default;
+$headings-margin-bottom:      0 !default;
+$headings-font-family:        null !default;
+$headings-font-weight:        500 !default;
+$headings-color:              null !default;
 
 //
 // Color system

--- a/core/sass/_variables.scss
+++ b/core/sass/_variables.scss
@@ -13,6 +13,7 @@ $headings-margin-bottom:      0 !default;
 $headings-font-family:        null !default;
 $headings-font-weight:        500 !default;
 $headings-color:              null !default;
+$paragraph-margin-bottom: 0 !default;
 
 //
 // Color system

--- a/core/sass/_variables.scss
+++ b/core/sass/_variables.scss
@@ -107,6 +107,8 @@ $widths: (
   auto: auto
 ) !default;
 
+$table-accent-bg: #f2f2f2 !default;
+$table-background-color: null !default;
 $table-border-color: $gray-200 !default;
 $table-border-width: 1px !default;
 

--- a/core/sass/_variables.scss
+++ b/core/sass/_variables.scss
@@ -1,4 +1,5 @@
 $font-size-base: 16px !default;
+$font-weight-base: normal !default;
 $border-radius: $font-size-base * 0.25 !default;
 $border-radius-lg: $font-size-base * 0.3 !default;
 $border-radius-sm: $font-size-base * 0.2 !default;
@@ -109,6 +110,9 @@ $widths: (
 
 $table-border-color: $gray-200 !default;
 $table-border-width: 1px !default;
+
+$body-color: $black !default;
+$body-bg: $white !default;
 
 $btn-padding-y:               8px !default;
 $btn-padding-x:               12px !default;

--- a/core/sass/_variables.scss
+++ b/core/sass/_variables.scss
@@ -134,7 +134,7 @@ $btn-line-height-lg:          $btn-line-height * 1.25 !default;
 
 $btn-border-width:            1px !default;
 
-$btn-font-weight:             $font-weight-normal !default;
+$btn-font-weight:             $font-weight-base !default;
 
 // Allows for customizing button radius independently from global border radius
 $btn-border-radius:           $border-radius !default;

--- a/core/sass/_variables.scss
+++ b/core/sass/_variables.scss
@@ -5,6 +5,7 @@ $font-family-base: $font-family-sans-serif !default;
 $border-radius: $font-size-base * 0.25 !default;
 $border-radius-lg: $font-size-base * 0.3 !default;
 $border-radius-sm: $font-size-base * 0.2 !default;
+$border-width: 1px !default;
 $line-height-base: 1.5 !default;
 $headings-line-height: 1.2 !default;
 $headings-ratios: (1: 2.25, 2: 2, 3: 1.75, 4: 1.5, 5: 1.25, 6: 1) !default;
@@ -14,6 +15,7 @@ $headings-font-family:        null !default;
 $headings-font-weight:        500 !default;
 $headings-color:              null !default;
 $paragraph-margin-bottom: 0 !default;
+$rounded-pill: 50 * $font-size-base !default;
 
 //
 // Color system
@@ -108,10 +110,12 @@ $widths: (
   auto: auto
 ) !default;
 
+$border-color: $gray-300 !default
+
 $table-accent-bg: #f2f2f2 !default;
 $table-background-color: null !default;
-$table-border-color: $gray-200 !default;
-$table-border-width: 1px !default;
+$table-border-color: $border-color !default;
+$table-border-width: $border-width !default;
 
 $body-color: $black !default;
 $body-bg: $white !default;
@@ -132,7 +136,7 @@ $btn-padding-x-lg:            $btn-font-size !default;
 $btn-font-size-lg:            1.25 * $btn-font-size !default;
 $btn-line-height-lg:          $btn-line-height * 1.25 !default;
 
-$btn-border-width:            1px !default;
+$btn-border-width:            $border-width !default;
 
 $btn-font-weight:             $font-weight-base !default;
 

--- a/core/sass/_variables.scss
+++ b/core/sass/_variables.scss
@@ -1,4 +1,7 @@
 $font-size-base: 16px !default;
+$border-radius: $font-size-base * 0.25 !default;
+$border-radius-lg: $font-size-base * 0.3 !default;
+$border-radius-sm: $font-size-base * 0.2 !default;
 $line-height-base: 1.5 !default;
 $headings-line-height: 1.2 !default;
 $headings-ratios: (1: 2.25, 2: 2, 3: 1.75, 4: 1.5, 5: 1.25, 6: 1) !default;
@@ -101,6 +104,31 @@ $widths: (
 
 $table-border-color: $gray-200 !default;
 $table-border-width: 1px !default;
+
+$btn-padding-y:               8px !default;
+$btn-padding-x:               12px !default;
+$btn-font-family:             $font-family-base !default;
+$btn-font-size:               $font-size-base !default;
+$btn-line-height:             1.25 * $btn-font-size !default;
+
+$btn-padding-y-sm:            0.25 * $btn-font-size !default;
+$btn-padding-x-sm:            0.5 * $btn-font-size !default;
+$btn-font-size-sm:            0.875 * $btn-font-size !default;
+$btn-line-height-sm:          $btn-line-height * 0.875 !default;
+
+$btn-padding-y-lg:            0.5 * $btn-font-size !default;
+$btn-padding-x-lg:            $btn-font-size !default;
+$btn-font-size-lg:            1.25 * $btn-font-size !default;
+$btn-line-height-lg:          $btn-line-height * 1.25 !default;
+
+$btn-border-width:            1px !default;
+
+$btn-font-weight:             $font-weight-normal !default;
+
+// Allows for customizing button radius independently from global border radius
+$btn-border-radius:           $border-radius !default;
+$btn-border-radius-lg:        $border-radius-lg !default;
+$btn-border-radius-sm:        $border-radius-sm !default;
 
 // Utility functions
 @function heading-size($n) { @return map-get($headings-ratios, $n) * $font-size-base; }


### PR DESCRIPTION
I make use of a lot of bootstrap variable overrides in my app and my goal is to share them all in a partial between my web & email layouts. This is an amazing start towards achieving that, but I noticed a lot of things that are configurable with variables in bootstrap 4 aren't in this gem, so I started converting everything hardcoded that I currently use into a variable. There is obviously still a lot of work to do here, which I'll try to keep submitting PRs for as I add more overrides to my app. 

Some notes:
1. `.btn td a` had default border color `#e9703e` which is orange ... seemed strange, so I changed it to `transparent` which is the bootstrap 4 default. This doesn't seem to come into play anyway since this will be mixed with the `btn-x` styles but I still thought it worth pointing out the change.
1. I'm not sure why `border-radius` has to be specified at `.btn`, `.btn td` and `.btn td a` but I'm leaving as-is as I assume there's a good reason for it
1. I actually have `$headings-margin-bottom: $font-size-base / 2;` in my app (same as bootstrap 4), but I saw that line was commented out in the code, so I removed the commented code and left the default `0` so as not to mess with anyone else
1. ~`body` had both `margin` and `Margin` properties, so I removed the redundant capitalized one~
1. It's unclear to me why things like the spacing utilities are duplicated between the `head.scss` & `_spacing.scss` files. Why not just `@import sass/spacing` in `head.scss`?
1. `.table-dark` & `table-light` weren't actually defined, despite it being in [the docs](https://bootstrapemail.com/docs/table), though `.table-inverse` & `.table-default` were, so I renamed them
1. `.table` had a hardcoded background of `$white` so I made that a variable, but also made the default `null` as Bootstrap 4 does so that it just inherits the body color, unless this var is explicitly changed.
1. `.thead-dark` & `.thead-light` seemed to be meant to be applied to `<table>`, but the [Bootstrap docs](https://getbootstrap.com/docs/4.3/content/tables/#table-head-options) indicate these classes should apply to `<thead>` so I loosened the specificity rules
1. The styles for `<p>` for some reason required class `p` for them to apply which is different from Bootstrap's behavior, so I changed them to apply to the tag itself.
1. The default `border-color` was `$gray-200` vs Bootstrap's `$gray-300`, so I changed it to match