### PR TITLE
Override Gmail styles that prevent certain styles from cascading

### DIFF
--- a/core/head.scss
+++ b/core/head.scss
@@ -36,6 +36,39 @@ a {
   text-decoration: none;
 }
 
+/*
+Gmail inserts the following 2 rules above this file in <head> and this overrides them
+
+body,
+td,
+input,
+textarea,
+select {
+  margin: 0;
+  font-family: Roboto, RobotoDraft, Helvetica, Arial, sans-serif
+}
+
+input,
+textarea,
+select {
+  font-size: 100%
+}
+*/
+body,
+td,
+input,
+textarea,
+select {
+  margin: unset;
+  font-family: unset;
+}
+
+input,
+textarea,
+select {
+  font-size: unset;
+}
+
 @media screen and (max-width: 600px) {
   //  Grid
   table.row {


### PR DESCRIPTION
Before (inconsistent application of desired font-face):
<img width="212" alt="Screen Shot 2019-09-13 at 4 15 43 PM" src="https://user-images.githubusercontent.com/157270/64899758-d7029600-d641-11e9-9aa9-271ed6899b63.png">

After:
<img width="233" alt="Screen Shot 2019-09-13 at 4 16 01 PM" src="https://user-images.githubusercontent.com/157270/64899764-dc5fe080-d641-11e9-8a90-3e6891d23488.png">
