### PR TITLE
replace uses of `color.adjust()` with a helper that will return hex codes

### DIFF
--- a/core/scss/components/_alert.scss
+++ b/core/scss/components/_alert.scss
@@ -1,5 +1,6 @@
 @use "sass:color";
 @use "../variable";
+@use "../helper";
 
 .alert {
   border-collapse: separate !important;
@@ -14,11 +15,11 @@
 
 @each $color, $value in variable.$theme-colors {
   .alert-#{$color} td {
-    background-color: color.adjust($value, $lightness: 40%);
-    border-color: color.adjust($value, $lightness: 35%);
-    color: color.adjust($value, $lightness: -30%);
+    background-color: helper.lighten-color($value, 40%);
+    border-color: helper.lighten-color($value, 35%);
+    color: helper.lighten-color($value, -30%);
     .hr > table > tbody > tr > td {
-      border-top: 1px solid color.adjust($value, $lightness: 35%);
+      border-top: 1px solid helper.lighten-color($value, 35%);
     }
   }
 }

--- a/core/scss/components/_table.scss
+++ b/core/scss/components/_table.scss
@@ -1,5 +1,6 @@
 @use "sass:color";
 @use "../variable";
+@use "../helper";
 
 //
 // Basic Bootstrap table
@@ -93,7 +94,7 @@
     &,
     > th,
     > td {
-      background-color: color.adjust($value, $lightness: 40%);
+      background-color: helper.lighten-color($value, 40%);
     }
   }
 }

--- a/core/scss/helpers/_functions.scss
+++ b/core/scss/helpers/_functions.scss
@@ -1,6 +1,7 @@
 @use "sass:color";
 @use "sass:math";
 @use "sass:meta";
+@use "sass:string";
 
 @function color-contrast($color) {
   $r: color.channel($color, "red", $space: rgb);
@@ -14,6 +15,10 @@
   } @else {
     @return #ffffff;
   }
+}
+
+@function lighten-color($color, $level) {
+  @return string.unquote('#' + string.slice(ie-hex-str(color.adjust($color, $lightness: $level)), 4));
 }
 
 @function tint-color($color, $level) {


### PR DESCRIPTION
Issues for alerts and tables are similar to bgcolor helpers discussed in https://github.com/bootstrap-email/bootstrap-email/issues/280

Also, lightening the theme's success color by 40% returns a aquamarine (#84E8BA) rather than the expected light olive green (#D1E7DD). I could not figure out a good fix for that, perhaps someone more familiar with color transformations can improve.

Note that `ie-hex-str` can be leveraged here, unlike modifying the results of mixing colors.