### PR TITLE
Add back ostruct

### DIFF
--- a/bootstrap-email.gemspec
+++ b/bootstrap-email.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
   s.add_runtime_dependency 'premailer', '~> 1.7'
   s.add_runtime_dependency 'sass-embedded', '~> 1.55'
+  s.add_runtime_dependency 'ostruct', '~> 0.6'
 
   s.required_ruby_version = '>= 2.0'
   s.metadata['rubygems_mfa_required'] = 'true'


### PR DESCRIPTION
Add back the open struct dependency, the codebase stopped using them so I thought it was safe, but it is possible people have older subdependencies that still rely on it or something and that is causing issues. Not a huge deal to just add it back.

Fixes: #285 